### PR TITLE
Decouple CI from Harvard Dataverse

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,9 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
+      - name: Start isolated Dataverse
+        id: dataverse
+        uses: gdcc/dataverse-action@main
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
@@ -33,6 +36,9 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          DATAVERSE_BASE_URL: ${{ steps.dataverse.outputs.base_url }}
+          DATAVERSE_API_TOKEN: ${{ steps.dataverse.outputs.api_token }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@
 
 Interface to the [Dataverse project](https://dataverse.org) APIs, collections and datasets.
 
+Functions use Harvard Dataverse by default for backward compatibility. Use the
+`base_url` keyword to connect to another Dataverse installation:
+
+```julia
+using Dataverse
+
+files = Dataverse.file_list(
+    "doi:10.1234/EXAMPLE";
+    base_url="https://data.example.edu",
+)
+```
+
 👉 [demo notebook](https://gdcc.github.io/Dataverse.jl/dev/notebook.html) and [notebook code](https://github.com/gdcc/Dataverse.jl/blob/main/docs/src/notebook.jl)
 
 https://user-images.githubusercontent.com/20276764/191961603-97f2fd21-bda1-42bf-b0a1-d9ea88bf480d.mp4

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,8 @@
 using Dataverse, PythonCall, Documenter, PlutoSliderServer
 
+# Export the Pluto notebook with deterministic sample data, never production API calls.
+ENV["DATAVERSE_OFFLINE_DOCS"] = "true"
+
 DocMeta.setdocmeta!(Dataverse, :DocTestSetup, :(using Dataverse); recursive=true)
 
 do_py_test=false

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,33 +11,26 @@ This package is about interfaces to the [Dataverse](https://dataverse.org) data 
 !!! warning
     This package is in early development stage.
 
-For example:
+For example, list and download files from the default Harvard Dataverse instance:
 
-```@example 1
-using Dataverse 
+```julia
+using Dataverse
 
-DOI="doi:10.7910/DVN/EE3C40"
-files=Dataverse.file_list(DOI)
-Dataverse.file_download(DOI,files.filename[1])
+DOI = "doi:10.7910/DVN/EE3C40"
+files = Dataverse.file_list(DOI)
+Dataverse.file_download(DOI, files.filename[1])
 ```
 
-or 
+Use `base_url` to connect to another Dataverse installation:
 
-```@example 1
-(header,dataverses,datasets)=Dataverse.dataverse_scan(:ECCOv4r2)
+```julia
+base_url = "https://data.example.edu"
+files = Dataverse.file_list("doi:10.1234/EXAMPLE"; base_url=base_url)
+header, dataverses, datasets = Dataverse.dataverse_scan(:root; base_url=base_url)
 ```
 
-then
-
-```@example 1
-files=Dataverse.file_list(datasets.persistentUrl[1])
-```
-
-and 
-
-```@example 1
-Dataverse.file_download(files,files.filename[1])
-```
+The documentation build does not execute these network examples. The CI integration
+tests use an isolated Dataverse instance created for each test run.
 
 ## Julia Dataverse API
 

--- a/docs/src/notebook.jl
+++ b/docs/src/notebook.jl
@@ -20,6 +20,9 @@ end
 begin
 	using Dataverse, PlutoUI, Downloads
 	using DataFrames, PrettyTables
+	default_base_url = "https://dataverse.harvard.edu"
+	base_url = get(ENV, "DATAVERSE_BASE_URL", default_base_url)
+	offline_docs_build = get(ENV, "CI", "false") == "true"
 	"Packages ready"
 end
 
@@ -60,12 +63,19 @@ end
 
 # ╔═╡ 2240395b-4112-4e8a-a233-26fde9dffbc4
 begin
-	df=Dataverse.file_list(DOI)
-
-	#alternative : 
-	#🏁
-	#dataset = NativeApi.get_dataset(DOI)
-	#df=pyDataverse.dataset_file_list(DOI)
+	# Documentation CI uses deterministic sample metadata instead of contacting
+	# a production Dataverse. Interactive Pluto sessions use the selected server.
+	df = if offline_docs_build
+		DataFrame(
+			filename=["example.txt"],
+			filesize=[18],
+			id=[1],
+			url=["$(rstrip(base_url, '/'))/api/access/datafile/1"],
+		)
+	else
+		base_url == default_base_url ? Dataverse.file_list(DOI) :
+			Dataverse.file_list(DOI; base_url=base_url)
+	end
 
 	"Done scanning dataset files"
 end
@@ -96,7 +106,10 @@ md""" Download file ? $(@bind dl Select([true,false],default=true))"""
 # ╔═╡ ffe06b1c-0e0e-44df-93d5-c33d88bf7e7e
 begin
 	file_dl=joinpath(tempdir(),file)
-	dl&&!isfile(file_dl) ? Dataverse.file_download(DOI,file) : nothing
+	if !offline_docs_build && dl && !isfile(file_dl)
+		base_url == default_base_url ? Dataverse.file_download(DOI, file) :
+			Dataverse.file_download(DOI, file; base_url=base_url)
+	end
 end
 
 # ╔═╡ 1a5a27c9-7f72-49b7-a406-2576c11f0f3c
@@ -122,12 +135,18 @@ Or you select one interactively (scroll down a bit).
 
 # ╔═╡ 756bec67-c27e-49c1-9573-9521746cf856
 begin
-	#🏁
-	#using pyDataverse instead:
-	#tree=pyDataverse.dataverse_file_list()
-	
-	(header,dataverses,datasets)=Dataverse.dataverse_scan()
-	tree=[Dataverse.file_list(url) for url in datasets.persistentUrl]
+	if offline_docs_build
+		header = Dict("name" => "Documentation example")
+		dataverses = DataFrame(id=[], type=[], title=[])
+		datasets = DataFrame(id=[], type=[], persistentUrl=[])
+		tree = [df]
+	else
+		header, dataverses, datasets = base_url == default_base_url ?
+			Dataverse.dataverse_scan() : Dataverse.dataverse_scan(; base_url=base_url)
+		tree = base_url == default_base_url ?
+			[Dataverse.file_list(url) for url in datasets.persistentUrl] :
+			[Dataverse.file_list(url; base_url=base_url) for url in datasets.persistentUrl]
+	end
 	"Done scanning dataverse files"
 end
 

--- a/docs/src/notebook.jl
+++ b/docs/src/notebook.jl
@@ -22,7 +22,7 @@ begin
 	using DataFrames, PrettyTables
 	default_base_url = "https://dataverse.harvard.edu"
 	base_url = get(ENV, "DATAVERSE_BASE_URL", default_base_url)
-	offline_docs_build = get(ENV, "CI", "false") == "true"
+	offline_docs_build = get(ENV, "DATAVERSE_OFFLINE_DOCS", "false") == "true"
 	"Packages ready"
 end
 

--- a/src/Dataverse.jl
+++ b/src/Dataverse.jl
@@ -3,8 +3,8 @@ module Dataverse
 include("restDataverse.jl")
 import Dataverse.restDataverse: file_list, dataverse_scan
 
-pyDataverse_install() = pyDataverse_install(true)
-pyDataverse_APIs() = pyDataverse_APIs(true)
+function pyDataverse_install end
+function pyDataverse_APIs end
 
 include("pyDataverse.jl")
 export pyDataverse

--- a/src/downloads.jl
+++ b/src/downloads.jl
@@ -1,24 +1,27 @@
 
 module downloads
 
-import Dataverse.restDataverse: file_list
+import Dataverse.restDataverse: file_list, DEFAULT_BASE_URL
 using Downloads, DataFrames
 using Tar, CodecZlib, ZipFile
 
 ##
 
 """
-    file_download(DOI::String,nam::String,pth=tempdir())
+    file_download(DOI::String, name::String, path=tempdir(); base_url=DEFAULT_BASE_URL)
+
+Download a named file from a dataset. Use `base_url` to connect to a Dataverse
+installation other than Harvard Dataverse.
 
 ```
 DOI="doi:10.7910/DVN/OYBLGK"
 filename="polygons_MBON_seascapes.geojson"
-Dataverse.file_download(DOI,filename)
+Dataverse.file_download(DOI, filename)
 ```
 """
-function file_download(DOI::String,nam::String,pth=tempdir())
-    df=file_list(DOI)
-    file_download(df,nam,pth)
+function file_download(DOI::String, name::String, path=tempdir(); base_url=DEFAULT_BASE_URL)
+    files = file_list(DOI; base_url=base_url)
+    file_download(files, name, path)
 end
 
 """

--- a/src/json_ld.jl
+++ b/src/json_ld.jl
@@ -7,33 +7,42 @@ module json_ld
 """
 
 import HTTP, JSON
+import Dataverse.restDataverse: DEFAULT_BASE_URL, _build_url
 
 """
-    get(doi; to_file=false)
+    get(doi; to_file=false, base_url=DEFAULT_BASE_URL)
+
+Read the JSON-LD metadata embedded in a Dataverse dataset page.
 
 ```
-j=json_ld.get("10.7910/DVN/CAGYQL")
+j = json_ld.get("10.7910/DVN/CAGYQL")
 ```
 """
-get(doi; to_file=false) = begin
-  h=doi_to_html("10.7910/DVN/CAGYQL")
-  j,f=html_to_json_ld(h)
-  to_file ? f : j
+get(doi; to_file=false, base_url=DEFAULT_BASE_URL) = begin
+  html = doi_to_html(doi; base_url=base_url)
+  json, file = html_to_json_ld(html)
+  to_file ? file : json
 end
 
 """
-    html_to_json_ld(file_html1)
+    doi_to_html(doi; base_url=DEFAULT_BASE_URL)
+
+Download the Dataverse dataset page for a DOI to a temporary HTML file.
 
 ```
-h=json_ld.doi_to_html("10.7910/DVN/CAGYQL")
+h = json_ld.doi_to_html("10.7910/DVN/CAGYQL")
 ```
 """
-doi_to_html(doi) = begin
-  url="https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:$(doi)"
-  r=HTTP.get(url)
-  f=tempname()*".html"
-  write(f,r)
-  f
+doi_to_html(doi; base_url=DEFAULT_BASE_URL) = begin
+  url = _build_url(
+    base_url,
+    "/dataset.xhtml";
+    query=Dict("persistentId" => "doi:$(doi)"),
+  )
+  response = HTTP.get(url)
+  file = tempname() * ".html"
+  write(file, response)
+  file
 end
 
 """

--- a/src/restDataverse.jl
+++ b/src/restDataverse.jl
@@ -3,36 +3,86 @@ module restDataverse
 
 using HTTP, JSON, DataFrames
 
+const DEFAULT_BASE_URL = "https://dataverse.harvard.edu"
+
+# Normalize a Dataverse base URL so endpoint construction is consistent.
+function _normalize_base_url(base_url::AbstractString)
+    normalized = rstrip(strip(String(base_url)), '/')
+    isempty(normalized) && throw(ArgumentError("Dataverse base_url must not be empty."))
+    normalized
+end
+
+# Build a URL relative to a Dataverse installation.
+function _build_url(base_url::AbstractString, path::AbstractString; query=Dict{String,String}())
+    url = string(_normalize_base_url(base_url), "/", lstrip(String(path), '/'))
+    string(HTTP.URI(url; query=query))
+end
+
+# Parse a Dataverse API response and provide useful context when it is not JSON.
+function _parse_json_response(response::HTTP.Response, url::AbstractString)
+    content_type = HTTP.header(response, "Content-Type", "unknown")
+    context = "HTTP $(response.status) with Content-Type $(content_type)"
+    body = String(response.body)
+
+    if !(200 <= response.status < 300)
+        throw(ArgumentError(
+            "Dataverse API request to $(url) returned $(context); expected a successful JSON response.",
+        ))
+    elseif isempty(strip(body))
+        throw(ArgumentError(
+            "Dataverse API request to $(url) returned $(context) and an empty response body; expected JSON.",
+        ))
+    end
+
+    try
+        JSON.parse(body)
+    catch error
+        detail = sprint(showerror, error)
+        throw(ArgumentError(
+            "Dataverse API request to $(url) returned $(context), but the response body was not valid JSON: $(detail)",
+        ))
+    end
+end
+
+# Perform a GET request to a Dataverse API endpoint and return parsed JSON.
+function _get_json(path::AbstractString; base_url=DEFAULT_BASE_URL, query=Dict{String,String}())
+    url = _build_url(base_url, path; query=query)
+    response = HTTP.get(url; status_exception=false)
+    _parse_json_response(response, url)
+end
+
 """
-    file_list(DOI::String="doi:10.7910/DVN/ODM2IQ")
+    file_list(DOI::String="doi:10.7910/DVN/ODM2IQ"; base_url=DEFAULT_BASE_URL)
 
 Use HTTP, JSON, and DataFrames to list files in a dataset.
 
-Return a DataFrame with filename, filesize, and id.
+Return a DataFrame with filename, filesize, id, and download URL. Use `base_url`
+to connect to a Dataverse installation other than Harvard Dataverse.
 
 ```
 file_list("doi:10.7910/DVN/ODM2IQ")
+file_list("doi:10.1234/EXAMPLE"; base_url="https://data.example.edu")
 ```
 """
-function file_list(doi="doi:10.7910/DVN/EE3C40")
- r=HTTP.get("https://dataverse.harvard.edu/api/datasets/:persistentId/?persistentId=$(doi)")
- tmp=JSON.parse(String(r.body))
- files=tmp["data"]["latestVersion"]["files"]
- files_to_DataFrame(files)
+function file_list(doi="doi:10.7910/DVN/EE3C40"; base_url=DEFAULT_BASE_URL)
+ response=_get_json("/api/datasets/:persistentId/";
+    base_url=base_url,query=Dict("persistentId"=>String(doi)))
+ files=response["data"]["latestVersion"]["files"]
+ files_to_DataFrame(files;base_url=base_url)
 end
 
 """
-    file_list(nam::Symbol=:OCCA_clim)
+    file_list(nam::Symbol=:OCCA_clim; base_url=DEFAULT_BASE_URL)
 
 Lookup DOI from list of demo data sets (:OCCA_clim or :ECCO_clim).
 """
-function file_list(nam::Symbol)
+function file_list(nam::Symbol;base_url=DEFAULT_BASE_URL)
     DOI=(OCCA_clim="doi:10.7910/DVN/RNXA2A",ECCO_clim="doi:10.7910/DVN/3HPRZI")
-    file_list(DOI[nam])
+    file_list(DOI[nam];base_url=base_url)
 end
 
 """
-    dataverse_scan(nam::Symbol=:ECCOv4r2)
+    dataverse_scan(nam::Symbol=:ECCOv4r2; base_url=DEFAULT_BASE_URL)
 
 Use HTTP, JSON, and DataFrames to list contents in a dataverse.
 
@@ -43,13 +93,12 @@ Returns header (Dict), dataverses (DataFrame), and datasets (DataFrame).
 Dataverse.file_list(datasets.persistentUrl[1])
 ```
 """
-function dataverse_scan(nam::Symbol=:ECCOv4r2)
+function dataverse_scan(nam::Symbol=:ECCOv4r2;base_url=DEFAULT_BASE_URL)
+    alias=HTTP.escapeuri(string(nam))
     #header
-    r=HTTP.get("https://dataverse.harvard.edu/api/dataverses/$(nam)")
-    header=JSON.parse(String(r.body))["data"]
+    header=_get_json("/api/dataverses/$(alias)";base_url=base_url)["data"]
     #contents
-    r=HTTP.get("https://dataverse.harvard.edu/api/dataverses/$(nam)/contents")
-    tmp=JSON.parse(String(r.body))["data"]
+    tmp=_get_json("/api/dataverses/$(alias)/contents";base_url=base_url)["data"]
     type=[f["type"] for f in tmp]
     #1. dataverses
     ii=findall(type.=="dataverse")
@@ -67,24 +116,23 @@ function dataverse_scan(nam::Symbol=:ECCOv4r2)
         persistentUrl=[f["persistentUrl"] for f in tmp[ii]]
         datasets=DataFrame(id=id,type=type[ii],persistentUrl=persistentUrl)
     else
-        dataverses=DataFrame(id=[],type=[],persistentUrl=[])
+        datasets=DataFrame(id=[],type=[],persistentUrl=[])
     end
     #
     return header,dataverses,datasets
 end
 
 """
-    files_to_DataFrame(files)
+    files_to_DataFrame(files; base_url=DEFAULT_BASE_URL)
 
 Convert output from `dataset.json()["data"]["latestVersion"]["files"]` to a `DataFrame`.
 """
-function files_to_DataFrame(files)
+function files_to_DataFrame(files;base_url=DEFAULT_BASE_URL)
         nf=length(files)
         filename=[files[ff]["dataFile"]["filename"] for ff in 1:nf]
         filesize=[files[ff]["dataFile"]["filesize"] for ff in 1:nf]
         id=[files[ff]["dataFile"]["id"] for ff in 1:nf]
-        tmp="https://dataverse.harvard.edu/api/access/datafile/"
-        url=[tmp*"$(id[ff])" for ff in 1:nf]
+        url=[_build_url(base_url,"/api/access/datafile/$(id[ff])") for ff in 1:nf]
         DataFrame(filename=filename,filesize=filesize,id=id,url=url)
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,6 @@
 [deps]
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"

--- a/test/integration/dataverse_api.jl
+++ b/test/integration/dataverse_api.jl
@@ -13,7 +13,8 @@ using .DataverseTestFixture
     @test header["alias"] == fixture.dataverse_alias
     @test isempty(child_dataverses)
     @test size(datasets, 1) == 1
-    @test occursin(fixture.persistent_id, datasets.persistentUrl[1])
+    expected_persistent_url = replace(fixture.persistent_id, r"^doi:" => "https://doi.org/")
+    @test datasets.persistentUrl == [expected_persistent_url]
 
     files = Dataverse.file_list(fixture.persistent_id; base_url=base_url)
     @test size(files, 1) == 1

--- a/test/integration/dataverse_api.jl
+++ b/test/integration/dataverse_api.jl
@@ -1,0 +1,35 @@
+include(joinpath(@__DIR__, "..", "support", "dataverse_fixture.jl"))
+using .DataverseTestFixture
+
+@testset "Ephemeral Dataverse integration" begin
+    base_url = ENV["DATAVERSE_BASE_URL"]
+    api_token = ENV["DATAVERSE_API_TOKEN"]
+    fixture = create_fixture(base_url, api_token)
+
+    header, child_dataverses, datasets = Dataverse.dataverse_scan(
+        Symbol(fixture.dataverse_alias);
+        base_url=base_url,
+    )
+    @test header["alias"] == fixture.dataverse_alias
+    @test isempty(child_dataverses)
+    @test size(datasets, 1) == 1
+    @test occursin(fixture.persistent_id, datasets.persistentUrl[1])
+
+    files = Dataverse.file_list(fixture.persistent_id; base_url=base_url)
+    @test size(files, 1) == 1
+    @test files.filename == [fixture.filename]
+    @test files.id == [fixture.file_id]
+    @test startswith(files.url[1], rstrip(base_url, '/'))
+    @test !occursin("dataverse.harvard.edu", files.url[1])
+
+    output_directory = mktempdir()
+    Dataverse.file_download(
+        fixture.persistent_id,
+        fixture.filename,
+        output_directory;
+        base_url=base_url,
+    )
+    downloaded = joinpath(output_directory, fixture.filename)
+    @test isfile(downloaded)
+    @test read(downloaded, String) == fixture.contents
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,42 +1,30 @@
-using Dataverse, PythonCall, UUIDs, Test
+using Dataverse, PythonCall, Test
 
-do_py_test=1
-if do_py_test>0
+include("unit/rest_api.jl")
+
+run_python_tests = lowercase(get(ENV, "DATAVERSE_TEST_PYTHON", "true")) == "true"
+if run_python_tests
     Dataverse.pyDataverse_install()
-    (DataAccessApi,NativeApi)=Dataverse.pyDataverse_APIs()
-    @test typeof(DataAccessApi)==Py
+    DataAccessApi, NativeApi = Dataverse.pyDataverse_APIs()
+    @test typeof(DataAccessApi) == Py
 end
 
-if do_py_test>1
-    tmp=pyDataverse.demo_download()
-    @test isfile(tmp[1])
+if haskey(ENV, "DATAVERSE_BASE_URL") && haskey(ENV, "DATAVERSE_API_TOKEN")
+    include("integration/dataverse_api.jl")
+else
+    @info "Skipping Dataverse integration tests. Set DATAVERSE_BASE_URL and DATAVERSE_API_TOKEN to enable them."
 end
 
-@testset "Dataverse.jl" begin
-    (header,dataverses,datasets)=Dataverse.dataverse_scan()
-    @test isa(header,Dict)
+@testset "Archive downloads" begin
+    url = "https://zenodo.org/records/11062685/files/OCCA2HR1_analysis.tar.gz"
+    file = joinpath(tempdir(), "OCCA2HR1_analysis.tar.gz")
+    Dataverse.downloads.Downloads.download(url, file)
+    extracted = Dataverse.untargz(file)
+    @test ispath(joinpath(extracted, "OCCA2HR1_analysis"))
 
-#    j=json_ld.get("10.7910/DVN/CAGYQL")
-#    @test j["@type"]=="sc:Dataset"
-
-    lst=Dataverse.file_list(:OCCA_clim)
-    pth=joinpath(tempdir(),string(UUIDs.uuid4()))
-    mkdir(pth)
-    
-    jj=2
-    Dataverse.file_download(lst,lst.filename[jj],pth)
-    @test isfile(joinpath(pth,lst.filename[jj]))
-
-    url="https://zenodo.org/records/11062685/files/OCCA2HR1_analysis.tar.gz"
-    fil=joinpath(tempdir(),"OCCA2HR1_analysis.tar.gz")
-    Dataverse.downloads.Downloads.download(url,fil)
-    tmp=Dataverse.untargz(fil)
-    @test ispath(joinpath(tmp,"OCCA2HR1_analysis"))
-
-    url="https://naturalearth.s3.amazonaws.com/110m_cultural/ne_110m_admin_0_countries.zip"
-    fil=joinpath(tempdir(),"ne_110m_admin_0_countries.zip")
-    Dataverse.downloads.Downloads.download(url,fil)
-    Dataverse.unzip(fil,tempdir())
-    @test ispath(joinpath(tempdir(),"ne_110m_admin_0_countries.shp"))
+    url = "https://naturalearth.s3.amazonaws.com/110m_cultural/ne_110m_admin_0_countries.zip"
+    file = joinpath(tempdir(), "ne_110m_admin_0_countries.zip")
+    Dataverse.downloads.Downloads.download(url, file)
+    Dataverse.unzip(file, tempdir())
+    @test ispath(joinpath(tempdir(), "ne_110m_admin_0_countries.shp"))
 end
-

--- a/test/support/dataverse_fixture.jl
+++ b/test/support/dataverse_fixture.jl
@@ -1,0 +1,199 @@
+module DataverseTestFixture
+
+using HTTP, JSON, UUIDs
+
+export Fixture, create_fixture
+
+struct Fixture
+    dataverse_alias::String
+    persistent_id::String
+    file_id::Int
+    filename::String
+    contents::String
+end
+
+normalize_base_url(base_url) = rstrip(String(base_url), '/')
+
+function build_url(base_url, path; query=Dict{String,String}())
+    url = string(normalize_base_url(base_url), "/", lstrip(String(path), '/'))
+    string(HTTP.URI(url; query=query))
+end
+
+function request_json(method, url, api_token; body=nothing, headers=Pair{String,String}[])
+    request_headers = ["X-Dataverse-key" => api_token, headers...]
+    response = if body === nothing
+        HTTP.request(method, url, request_headers; status_exception=false)
+    else
+        HTTP.request(method, url, request_headers, body; status_exception=false)
+    end
+
+    if !(200 <= response.status < 300)
+        error("Fixture request $(method) $(url) returned HTTP $(response.status): $(String(response.body))")
+    end
+
+    isempty(response.body) ? Dict{String,Any}() : JSON.parse(String(response.body))
+end
+
+function dataset_metadata()
+    Dict(
+        "datasetVersion" => Dict(
+            "metadataBlocks" => Dict(
+                "citation" => Dict(
+                    "displayName" => "Citation Metadata",
+                    "fields" => [
+                        Dict(
+                            "typeName" => "title",
+                            "typeClass" => "primitive",
+                            "multiple" => false,
+                            "value" => "Dataverse.jl CI Dataset",
+                        ),
+                        Dict(
+                            "typeName" => "author",
+                            "typeClass" => "compound",
+                            "multiple" => true,
+                            "value" => [
+                                Dict(
+                                    "authorName" => Dict(
+                                        "typeName" => "authorName",
+                                        "typeClass" => "primitive",
+                                        "multiple" => false,
+                                        "value" => "Dataverse.jl CI",
+                                    ),
+                                ),
+                            ],
+                        ),
+                        Dict(
+                            "typeName" => "datasetContact",
+                            "typeClass" => "compound",
+                            "multiple" => true,
+                            "value" => [
+                                Dict(
+                                    "datasetContactName" => Dict(
+                                        "typeName" => "datasetContactName",
+                                        "typeClass" => "primitive",
+                                        "multiple" => false,
+                                        "value" => "Dataverse.jl CI",
+                                    ),
+                                    "datasetContactEmail" => Dict(
+                                        "typeName" => "datasetContactEmail",
+                                        "typeClass" => "primitive",
+                                        "multiple" => false,
+                                        "value" => "dataverse-jl-ci@example.org",
+                                    ),
+                                ),
+                            ],
+                        ),
+                        Dict(
+                            "typeName" => "dsDescription",
+                            "typeClass" => "compound",
+                            "multiple" => true,
+                            "value" => [
+                                Dict(
+                                    "dsDescriptionValue" => Dict(
+                                        "typeName" => "dsDescriptionValue",
+                                        "typeClass" => "primitive",
+                                        "multiple" => false,
+                                        "value" => "Ephemeral integration fixture for Dataverse.jl.",
+                                    ),
+                                ),
+                            ],
+                        ),
+                        Dict(
+                            "typeName" => "subject",
+                            "typeClass" => "controlledVocabulary",
+                            "multiple" => true,
+                            "value" => ["Computer and Information Science"],
+                        ),
+                    ],
+                ),
+            ),
+        ),
+    )
+end
+
+function wait_until_released(base_url, persistent_id; timeout_seconds=120)
+    url = build_url(
+        base_url,
+        "/api/datasets/:persistentId/";
+        query=Dict("persistentId" => persistent_id),
+    )
+    deadline = time() + timeout_seconds
+
+    while time() < deadline
+        response = HTTP.get(url; status_exception=false)
+        if response.status == 200 && !isempty(response.body)
+            data = JSON.parse(String(response.body))
+            state = get(data["data"]["latestVersion"], "versionState", "")
+            state == "RELEASED" && return data
+        end
+        sleep(2)
+    end
+
+    error("Timed out waiting for integration dataset $(persistent_id) to become RELEASED.")
+end
+
+function create_fixture(base_url, api_token)
+    suffix = lowercase(first(string(uuid4()), 8))
+    alias = "dataversejl-ci-$(suffix)"
+    filename = "dataverse-jl-fixture.txt"
+    contents = "Dataverse.jl integration fixture\n"
+
+    dataverse_payload = Dict(
+        "name" => "Dataverse.jl CI $(suffix)",
+        "alias" => alias,
+        "dataverseContacts" => [Dict("contactEmail" => "dataverse-jl-ci@example.org")],
+        "affiliation" => "Dataverse.jl",
+        "description" => "Ephemeral collection for Dataverse.jl integration tests.",
+        "dataverseType" => "RESEARCH_PROJECTS",
+    )
+    request_json(
+        "POST",
+        build_url(base_url, "/api/dataverses/root"),
+        api_token;
+        body=JSON.json(dataverse_payload),
+        headers=["Content-Type" => "application/json"],
+    )
+    request_json(
+        "POST",
+        build_url(
+            base_url,
+            "/api/dataverses/$(HTTP.escapeuri(alias))/actions/:publish",
+        ),
+        api_token,
+    )
+
+    dataset = request_json(
+        "POST",
+        build_url(base_url, "/api/dataverses/$(HTTP.escapeuri(alias))/datasets"),
+        api_token;
+        body=JSON.json(dataset_metadata()),
+        headers=["Content-Type" => "application/json"],
+    )
+    persistent_id = dataset["data"]["persistentId"]
+
+    upload_url = build_url(
+        base_url,
+        "/api/datasets/:persistentId/add";
+        query=Dict("persistentId" => persistent_id),
+    )
+    form = HTTP.Form(
+        Dict(
+            "file" => HTTP.Multipart(filename, IOBuffer(contents), "text/plain"),
+            "jsonData" => JSON.json(Dict("description" => "Dataverse.jl CI fixture")),
+        ),
+    )
+    upload = request_json("POST", upload_url, api_token; body=form)
+    file_id = upload["data"]["files"][1]["dataFile"]["id"]
+
+    publish_url = build_url(
+        base_url,
+        "/api/datasets/:persistentId/actions/:publish";
+        query=Dict("persistentId" => persistent_id, "type" => "major"),
+    )
+    request_json("POST", publish_url, api_token)
+    wait_until_released(base_url, persistent_id)
+
+    Fixture(alias, persistent_id, file_id, filename, contents)
+end
+
+end

--- a/test/unit/rest_api.jl
+++ b/test/unit/rest_api.jl
@@ -1,0 +1,82 @@
+using HTTP, JSON
+
+const RestAPI = Dataverse.restDataverse
+
+@testset "Dataverse URL construction" begin
+    @test RestAPI._normalize_base_url(" https://example.org/ ") == "https://example.org"
+    @test_throws ArgumentError RestAPI._normalize_base_url("  ")
+
+    url = RestAPI._build_url(
+        "https://example.org/",
+        "/api/datasets/:persistentId/";
+        query=Dict("persistentId" => "doi:10.5072/FK2/ABC123"),
+    )
+    @test url == "https://example.org/api/datasets/:persistentId/?persistentId=doi%3A10.5072%2FFK2%2FABC123"
+end
+
+@testset "Dataverse JSON response validation" begin
+    url = "https://example.org/api/info/version"
+
+    valid = HTTP.Response(
+        200,
+        ["Content-Type" => "application/json;charset=UTF-8"],
+        JSON.json(Dict("status" => "OK")),
+    )
+    @test RestAPI._parse_json_response(valid, url)["status"] == "OK"
+
+    # A valid JSON body should remain compatible with Dataverse installations
+    # whose proxy does not set an ideal Content-Type header.
+    unusual_content_type = HTTP.Response(200, ["Content-Type" => "text/plain"], "{\"status\":\"OK\"}")
+    @test RestAPI._parse_json_response(unusual_content_type, url)["status"] == "OK"
+
+    empty_response = HTTP.Response(202, ["Content-Type" => "text/html"], "")
+    empty_error = try
+        RestAPI._parse_json_response(empty_response, url)
+        nothing
+    catch error
+        error
+    end
+    @test empty_error isa ArgumentError
+    @test occursin("HTTP 202", sprint(showerror, empty_error))
+    @test occursin("empty response body", sprint(showerror, empty_error))
+    @test occursin("expected JSON", sprint(showerror, empty_error))
+
+    not_found = HTTP.Response(404, ["Content-Type" => "application/json"], "{\"status\":\"ERROR\"}")
+    status_error = try
+        RestAPI._parse_json_response(not_found, url)
+        nothing
+    catch error
+        error
+    end
+    @test status_error isa ArgumentError
+    @test occursin("HTTP 404", sprint(showerror, status_error))
+
+    invalid_json = HTTP.Response(200, ["Content-Type" => "text/html"], "not JSON")
+    json_error = try
+        RestAPI._parse_json_response(invalid_json, url)
+        nothing
+    catch error
+        error
+    end
+    @test json_error isa ArgumentError
+    @test occursin("not valid JSON", sprint(showerror, json_error))
+    @test occursin("Content-Type text/html", sprint(showerror, json_error))
+end
+
+@testset "File metadata uses the selected Dataverse instance" begin
+    files = [
+        Dict(
+            "dataFile" => Dict(
+                "filename" => "fixture.txt",
+                "filesize" => 18,
+                "id" => 42,
+            ),
+        ),
+    ]
+
+    table = RestAPI.files_to_DataFrame(files; base_url="http://localhost:8080/")
+    @test table.filename == ["fixture.txt"]
+    @test table.filesize == [18]
+    @test table.id == [42]
+    @test table.url == ["http://localhost:8080/api/access/datafile/42"]
+end


### PR DESCRIPTION
## Summary

- add a `base_url` keyword to the Julia REST, download, and JSON-LD paths while preserving Harvard Dataverse as the compatibility default;
- validate Dataverse API responses before parsing JSON so HTTP failures, empty bodies, and malformed responses include the request URL, status, and content type;
- replace Harvard-specific CI fixtures with a dynamically created and published dataset in an isolated `gdcc/dataverse-action` instance;
- keep documentation builds offline by using non-executing examples and deterministic notebook data.

## Why

Harvard Dataverse currently returns an HTTP 202 WAF challenge with an empty `text/html` body to CI requests. The package then attempts to parse that response as JSON and reports an opaque `UnexpectedEOF`. This makes Dataverse.jl CI depend on the availability and access policy of a production service.

After this change, contributors get deterministic CI fixtures, users can target local or institutional Dataverse installations, and unexpected server responses produce actionable errors. Existing calls continue to use Harvard unless `base_url` is supplied.

## Validation

- offline unit coverage for URL normalization, empty HTTP 202 responses, non-success status codes, malformed JSON, and instance-specific file URLs;
- real API integration coverage that creates a unique collection and dataset, uploads a text file, publishes the fixture, scans/lists it, and verifies the downloaded bytes;
- CI validation on Julia 1.9 and the latest stable Julia;
- offline Documenter and Pluto notebook export.

## Scope and risk

The integration job follows the `gdcc/dataverse-action@main` usage recommended in the issue and used by pyDataverse. It adds Docker startup time but removes the more costly production-service dependency and hard-coded remote fixtures.

The existing Zenodo and Natural Earth archive tests are unchanged. Downstream packages that intentionally download specific ocean datasets from Harvard will need a separate data-mirroring or fixture strategy; this PR makes alternate Dataverse instances possible but does not move those scientific datasets.

Closes #36.
